### PR TITLE
add snake case param name

### DIFF
--- a/lib/internal/Magento/Framework/MessageQueue/MessageEncoder.php
+++ b/lib/internal/Magento/Framework/MessageQueue/MessageEncoder.php
@@ -176,10 +176,14 @@ class MessageEncoder
                             ->convertValue($message[$paramPosition], $paramType);
                     }
                 } else {
+                    $snakeCaseParamName = strtolower(preg_replace("/(?<=\\w)(?=[A-Z])/", "_$1", $paramName));
                     /** Encode parameters according to their names in method signature */
-                    if (isset($message[$paramName])) {
+                    if (isset($message[$paramName]) || isset($message[$snakeCaseParamName])) {
+                        $paramValue = isset($message[$paramName])
+                            ? $message[$paramName]
+                            : $message[$snakeCaseParamName];
                         $convertedMessage[$paramName] = $this->getConverter($direction)
-                            ->convertValue($message[$paramName], $paramType);
+                            ->convertValue($paramValue, $paramType);
                     }
                 }
 


### PR DESCRIPTION
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
If we created service interface when have method `public function importQty(object $productQty)`
after send bulk request via url rest/async/bulk/V1/my_module/qtyUpdate include body
`[
    {
        "product_qty": {
            "template_id": 11831,
            "sku": "SKU0000100863",
            "qty": 13.0
        }
    },
    {
        "product_qty": {
            "template_id": 11821,
            "sku": "SKU0000138399",
            "qty": 13.0
        }
    }
]` then we get 202 status code and response text
`{
    "bulk_uuid": "942a14e7-431f-4a68-8009-2d1671b90eed",
    "request_items": [
        {
            "id": 0,
            "data_hash": "64172f83f6b3955c91b4ed80117d6d26b4b3f81be61371b2e4c1769c6c93cf1f",
            "status": "accepted"
        },
        {
            "id": 1,
            "data_hash": "132179362258e95fad607d91cbb96c7300c7620c3665fcff3476146625189557",
            "status": "accepted"
        }
    ],
    "errors": false
}`
after we send get request on url rest/V1/bulk/7e989285-c171-4c7b-b9c1-f3d77a7459cc/status and see this error 
`{
    "operations_list": [
        {
            "id": 0,
            "status": 3,
            "result_message": "Data item corresponding to \"productQty\" must be specified in the message with topic \"async.utires.odoointegration.api.productimportmanagementinterface.importqty.post\".",
            "error_code": 0
        },
        {
            "id": 1,
            "status": 3,
            "result_message": "Data item corresponding to \"productQty\" must be specified in the message with topic",
            "error_code": 0
        }
    ],
    "user_type": 1,
    "bulk_id": "7e989285-c171-4c7b-b9c1-f3d77a7459cc",
    "start_time": "2021-01-15 14:48:01",
    "user_id": 96,
    "operation_count": 2
}`
because vendor/magento/framework-message-queue/MessageEncoder.php class doesn't use $snakeCaseParamName variable how vendor/magento/framework/Webapi/ServiceInputProcessor.php
### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
1. we sent `[
    {
        "product_qty": {
            "template_id": 11831,
            "sku": "SKU0000100863",
            "qty": 13.0
        }
    },
    {
        "product_qty": {
            "template_id": 11821,
            "sku": "SKU0000138399",
            "qty": 13.0
        }
    }
]` we get `Service execution success `


### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)


### Resolved issues:
1. [x] resolves magento/magento2#31882: add snake case param name